### PR TITLE
AB#1852 Remove /etc/kubernetes from mount options

### DIFF
--- a/deploy/edgeless/csi-azuredisk-controller.yaml
+++ b/deploy/edgeless/csi-azuredisk-controller.yaml
@@ -170,8 +170,6 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-            - mountPath: /etc/kubernetes/
-              name: azure-cred
           resources:
             limits:
               cpu: 1
@@ -182,7 +180,3 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
-        - name: azure-cred
-          hostPath:
-            path: /etc/kubernetes/
-            type: DirectoryOrCreate

--- a/deploy/edgeless/csi-azuredisk-node.yaml
+++ b/deploy/edgeless/csi-azuredisk-node.yaml
@@ -133,8 +133,6 @@ spec:
             - mountPath: /var/lib/kubelet/
               mountPropagation: Bidirectional
               name: mountpoint-dir
-            - mountPath: /etc/kubernetes/
-              name: azure-cred
             - mountPath: /dev
               name: device-dir
             - mountPath: /sys/bus/scsi/devices
@@ -161,10 +159,6 @@ spec:
             path: /var/lib/kubelet/plugins_registry/
             type: DirectoryOrCreate
           name: registration-dir
-        - hostPath:
-            path: /etc/kubernetes/
-            type: DirectoryOrCreate
-          name: azure-cred
         - hostPath:
             path: /dev
             type: Directory


### PR DESCRIPTION
The cloud config file will be added to Azure (and also other CSPs) in the form of a Kubernetes secret, meaning it will never be present as a file in `/etc/kubernetes/`.
So we can just remove the mounting of `/etc/kubernetes/` into the driver pods.
This change does not impact user experience in any way: name and namespace of the secret will be set in the yaml files of the driver pods (just as they are now). The difference to our current setup up will be that, in the future, the users won't have to manually create the secret file, as it will already be present.