### PR TITLE
AB#2081 Encrypted block storage

### DIFF
--- a/pkg/azuredisk/nodeserver.go
+++ b/pkg/azuredisk/nodeserver.go
@@ -125,12 +125,6 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 		}
 	}
 
-	// If the access type is block, do nothing for stage
-	switch req.GetVolumeCapability().GetAccessType().(type) {
-	case *csi.VolumeCapability_Block:
-		return &csi.NodeStageVolumeResponse{}, nil
-	}
-
 	mnt, err := d.ensureMountPoint(target)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not mount target %q: %v", target, err)
@@ -170,6 +164,12 @@ func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRe
 	devicePath, err := d.cryptMapper.OpenCryptDevice(ctx, source, diskName, integrity)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeStageVolume failed on volume %v to %s, open crypt device failed: %v", source, target, err))
+	}
+
+	if blk := volumeCapability.GetBlock(); blk != nil {
+		// Noop for Block NodeStageVolume
+		klog.V(4).Infof("NodeStageVolume succeeded on %s to %s, capability is block so this is a no-op", diskURI, target)
+		return &csi.NodeStageVolumeResponse{}, nil
 	}
 
 	// FormatAndMount will format only if needed
@@ -280,16 +280,16 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	switch req.GetVolumeCapability().GetAccessType().(type) {
 	case *csi.VolumeCapability_Block:
-		lun, ok := req.PublishContext[consts.LUN]
-		if !ok {
-			return nil, status.Error(codes.InvalidArgument, "lun not provided")
-		}
-		var err error
-		source, err = d.getDevicePathWithLUN(lun)
+		diskName, err := d.getVolumeName(volumeID)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to find device path with lun %s. %v", lun, err)
+			return nil, status.Errorf(codes.InvalidArgument, "Unable to parse disk URI: %v", err)
 		}
-		klog.V(2).Infof("NodePublishVolume [block]: found device path %s with lun %s", source, lun)
+		source, err = d.evalSymLinks(filepath.Join("/dev/mapper", diskName))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "NodePublishVolume: can not evaluate source path: %v", err)
+		}
+
+		klog.V(2).Infof("NodePublishVolume [block]: found device path %s", source)
 		err = d.ensureBlockTargetFile(target)
 		if err != nil {
 			return nil, err

--- a/pkg/azuredisk/nodeserver_test.go
+++ b/pkg/azuredisk/nodeserver_test.go
@@ -656,9 +656,6 @@ func TestNodePublishVolume(t *testing.T) {
 	d, _ := NewFakeDriver(t)
 
 	volumeCap := csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER}
-	publishContext := map[string]string{
-		consts.LUN: "/dev/01",
-	}
 	errorMountSource, err := testutil.GetWorkDirPath("error_mount_source")
 	assert.NoError(t, err)
 	alreadyMountedTarget, err := testutil.GetWorkDirPath("false_is_likely_exist_target")
@@ -730,29 +727,6 @@ func TestNodePublishVolume(t *testing.T) {
 			expectedErr: testutil.TestError{
 				DefaultError: status.Errorf(codes.Internal, fmt.Sprintf("could not mount target \"%s\": "+
 					"mkdir %s: not a directory", azuredisk, azuredisk)),
-			},
-		},
-		{
-			desc: "[Error] Lun not provided",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: stdVolCapBlock},
-				VolumeId:          "vol_1",
-				TargetPath:        azuredisk,
-				StagingTargetPath: sourceTest,
-				Readonly:          true},
-			expectedErr: testutil.TestError{
-				DefaultError: status.Error(codes.InvalidArgument, "lun not provided"),
-			},
-		},
-		{
-			desc: "[Error] Lun not valid",
-			req: csi.NodePublishVolumeRequest{VolumeCapability: &csi.VolumeCapability{AccessMode: &volumeCap, AccessType: stdVolCapBlock},
-				VolumeId:          "vol_1",
-				TargetPath:        azuredisk,
-				StagingTargetPath: sourceTest,
-				PublishContext:    publishContext,
-				Readonly:          true},
-			expectedErr: testutil.TestError{
-				DefaultError: status.Error(codes.Internal, "failed to find device path with lun /dev/01. cannot parse deviceInfo: /dev/01"),
 			},
 		},
 		{


### PR DESCRIPTION
* Move the `no-op` of staging block storage to after it has been mapped by `cryptsetup` in `NodeStageVolume`
* Fix device path evaluation in for block storage in `NodePublishVolume` to use the mapped device