### PR TITLE
Build disk plugin binary in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:bullseye AS build
+
+ENV DEBIAN_FRONTEND="noninteractive"
+RUN apt-get update && apt-get install -y build-essential wget pkg-config libcryptsetup12 libcryptsetup-dev
+ARG GO_VER=1.18.2
+RUN wget https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
+    rm go${GO_VER}.linux-amd64.tar.gz
+ENV PATH ${PATH}:/usr/local/go/bin
+
+WORKDIR /azurediskplugin
+COPY pkg ./pkg
+COPY vendor ./vendor
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+
+ARG ARCH
+ARG LDFLAGS
+ARG PLUGIN_NAME
+RUN CGO_ENABLED=1 GOOS=linux GOARCH="${ARCH}" go build -trimpath -a -ldflags "${LDFLAGS}" -mod vendor -o "/azurediskplugin/${PLUGIN_NAME}" ./pkg/azurediskplugin
+
+FROM scratch AS export
+ARG PLUGIN_NAME
+COPY --from=build /azurediskplugin/${PLUGIN_NAME} /

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,8 @@ e2e-teardown:
 
 .PHONY: azuredisk
 azuredisk:
-	CGO_ENABLED=1 GOOS=linux GOARCH=$(ARCH) go build -trimpath -a -ldflags ${LDFLAGS} -mod vendor -o _output/${ARCH}/${PLUGIN_NAME} ./pkg/azurediskplugin
+	mkdir -p _output/${ARCH} && \
+    DOCKER_BUILDKIT=1 docker build --build-arg ARCH=${ARCH} --build-arg LDFLAGS=${LDFLAGS} --build-arg PLUGIN_NAME=${PLUGIN_NAME} -o _output/${ARCH} .
 
 .PHONY: azuredisk-v2
 azuredisk-v2:


### PR DESCRIPTION
Recently upgrade my OS which resulted in some issues when building the disk plugin, since the binary is built on the local system and then copied into the final docker image.
This implements a workaround by building the binary in docker