### PR TITLE
Add index for consumption as repo

### DIFF
--- a/charts/edgeless/index.yaml
+++ b/charts/edgeless/index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  azuredisk-csi-driver:
+  - apiVersion: v1
+    appVersion: v1.0.0
+    created: "2022-09-28T11:13:35.77182202+02:00"
+    description: Azure disk Container Storage Interface (CSI) Storage Plugin with
+      on-node encryption support
+    digest: 7272ead1ee433ed3e77440901e1607701c955daab3161dc3e008ae2323858d0a
+    name: azuredisk-csi-driver
+    urls:
+    - v1.0.0/azuredisk-csi-driver.tgz
+    version: v1.0.0
+generated: "2022-09-28T11:13:35.770299627+02:00"


### PR DESCRIPTION
Created using:
helm repo index edgeless.

Allows us to do something like this:
helm repo add tmp3 https://raw.githubusercontent.com/edgelesssys/constellation-azuredisk-csi-driver/feat/repo-index/charts/edgeless.

I need this to reference the chart as a dependency of another chart :).
