### PR TITLE
Release v1.2.0

### DIFF
--- a/charts/edgeless/Chart.yaml
+++ b/charts/edgeless/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "v1.1.0"
+appVersion: "v1.2.0"
 description: Azure disk Container Storage Interface (CSI) Storage Plugin with on-node encryption support
 name: azuredisk-csi-driver
-version: v1.1.2
+version: v1.2.0

--- a/charts/edgeless/templates/csi-azuredisk-controller.yaml
+++ b/charts/edgeless/templates/csi-azuredisk-controller.yaml
@@ -66,7 +66,7 @@ spec:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
             - "--v=2"
-            - "--timeout=15s"
+            - "--timeout=30s"
             - "--leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "--worker-threads={{ .Values.controller.provisionerWorkerThreads }}"
@@ -94,8 +94,8 @@ spec:
             - "-leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "-worker-threads={{ .Values.controller.attacherWorkerThreads }}"
-            - "-kube-api-qps=50"
-            - "-kube-api-burst=100"
+            - "-kube-api-qps=200"
+            - "-kube-api-burst=400"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -157,6 +157,18 @@ spec:
             - name: socket-dir
               mountPath: /csi
           resources: {{- toYaml .Values.controller.resources.livenessProbe | nindent 12 }}
+{{- if eq .Values.controller.enableTrafficManager true }}
+        - image: mcr.microsoft.com/aks/ccp/ccp-auto-thrust:master.221118.2
+          imagePullPolicy: IfNotPresent
+          name: proxy
+          command:
+            - /ccp-auto-thrust
+          args:
+            - "--port={{ .Values.controller.trafficManagerPort }}"
+          ports:
+          - containerPort: {{ .Values.controller.trafficManagerPort }}
+            protocol: TCP
+{{- end }}
         - name: azuredisk
 {{- if hasPrefix "/" .Values.image.azuredisk.repository }}
           image: "{{ .Values.image.baseRepo }}{{ .Values.image.azuredisk.repository }}:{{ .Values.image.azuredisk.tag }}"
@@ -176,6 +188,8 @@ spec:
             - "--user-agent-suffix={{ .Values.driver.userAgentSuffix }}"
             - "--allow-empty-cloud-config={{ .Values.controller.allowEmptyCloudConfig }}"
             - "--vmss-cache-ttl-seconds={{ .Values.controller.vmssCacheTTLInSeconds }}"
+            - "--enable-traffic-manager={{ .Values.controller.enableTrafficManager }}"
+            - "--traffic-manager-port={{ .Values.controller.trafficManagerPort }}"
           ports:
             - containerPort: {{ .Values.controller.livenessProbe.healthPort }}
               name: healthz

--- a/charts/edgeless/templates/csi-snapshot-controller.yaml
+++ b/charts/edgeless/templates/csi-snapshot-controller.yaml
@@ -55,4 +55,28 @@ spec:
             - "--leader-election-namespace={{ .Release.Namespace }}"
           resources: {{- toYaml .Values.snapshot.snapshotController.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.snapshot.image.csiSnapshotController.pullPolicy }}
+
+---
+{{- if .Values.snapshot.VolumeSnapshotClass.enabled -}}
+kind: VolumeSnapshotClass
+apiVersion: snapshot.storage.k8s.io/v1
+metadata:
+  name: {{ .Values.snapshot.VolumeSnapshotClass.name }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+driver: {{ .Values.driver.name }}
+deletionPolicy: {{ .Values.snapshot.VolumeSnapshotClass.deletionPolicy }}
+parameters:
+  incremental: {{ .Values.snapshot.VolumeSnapshotClass.parameters.incremental }}
+  {{- if ne .Values.snapshot.VolumeSnapshotClass.parameters.resourceGroup "" }}
+  resourceGroup: {{ .Values.snapshot.VolumeSnapshotClass.parameters.resourceGroup }}
+  {{- end }}
+  tags: {{ .Values.snapshot.VolumeSnapshotClass.parameters.tags }}
+{{- with .Values.snapshot.VolumeSnapshotClass.additionalLabels }}
+additionalLabels:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/edgeless/values.yaml
+++ b/charts/edgeless/values.yaml
@@ -2,27 +2,27 @@ image:
   baseRepo: mcr.microsoft.com
   azuredisk:
     repository: ghcr.io/edgelesssys/constellation/azure-csi-driver
-    tag: v1.2.0
+    tag: v1.2.0@sha256:a5346a6650ec702d0ba86acee808c0102340ea4cb3375d956c6b34020b292527
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: /oss/kubernetes-csi/csi-provisioner
-    tag: v3.3.0
+    tag: v3.3.0@sha256:3ef7d954946bd1cf9e5e3564a8d1acf8e5852616f7ae96bcbc5ced8c275483ee
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: /oss/kubernetes-csi/csi-attacher
-    tag: v4.0.0
+    tag: v4.0.0@sha256:bc317fea7e7bbaff65130d7ac6ea7c96bc15eb1f086374b8c3359f11988ac024
     pullPolicy: IfNotPresent
   csiResizer:
     repository: /oss/kubernetes-csi/csi-resizer
-    tag: v1.6.0
+    tag: v1.6.0@sha256:9ba6483d2f8aa6051cb3a50e42d638fc17a6e4699a6689f054969024b7c12944
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: /oss/kubernetes-csi/livenessprobe
-    tag: v2.8.0
+    tag: v2.8.0@sha256:fcb73e1939d9abeb2d1e1680b476a10a422a04a73ea5a65e64eec3fde1f2a5a1
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: /oss/kubernetes-csi/csi-node-driver-registrar
-    tag: v2.6.2
+    tag: v2.6.2@sha256:515b883deb0ae8d58eef60312f4d460ff8a3f52a2a5e487c94a8ebb2ca362720
     pullPolicy: IfNotPresent
 
 serviceAccount:

--- a/charts/edgeless/values.yaml
+++ b/charts/edgeless/values.yaml
@@ -2,27 +2,27 @@ image:
   baseRepo: mcr.microsoft.com
   azuredisk:
     repository: ghcr.io/edgelesssys/constellation/azure-csi-driver
-    tag: v1.1.0
+    tag: v1.2.0
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: /oss/kubernetes-csi/csi-provisioner
-    tag: v3.2.0
+    tag: v3.3.0
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: /oss/kubernetes-csi/csi-attacher
-    tag: v3.5.0
+    tag: v4.0.0
     pullPolicy: IfNotPresent
   csiResizer:
     repository: /oss/kubernetes-csi/csi-resizer
-    tag: v1.5.0
+    tag: v1.6.0
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: /oss/kubernetes-csi/livenessprobe
-    tag: v2.7.0
+    tag: v2.8.0
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: /oss/kubernetes-csi/csi-node-driver-registrar
-    tag: v2.5.1
+    tag: v2.6.2
     pullPolicy: IfNotPresent
 
 serviceAccount:
@@ -40,6 +40,8 @@ controller:
   cloudConfigSecretName: azureconfig
   cloudConfigSecretNamespace: kube-system
   allowEmptyCloudConfig: false
+  enableTrafficManager: false
+  trafficManagerPort: 7788
   replicas: 1
   metricsPort: 29604
   livenessProbe:
@@ -49,7 +51,7 @@ controller:
   disableAvailabilitySetNodes: false
   vmType: ""
   provisionerWorkerThreads: 100
-  attacherWorkerThreads: 500
+  attacherWorkerThreads: 1000
   vmssCacheTTLInSeconds: -1
   logLevel: 5
   tolerations:
@@ -153,6 +155,15 @@ snapshot:
       requests:
         cpu: 10m
         memory: 20Mi
+  VolumeSnapshotClass:
+    enabled: false
+    name: csi-azuredisk-vsc
+    deletionPolicy: Delete
+    parameters:
+      incremental: '"true"' # available values: "true", "false" ("true" by default for Azure Public Cloud, and "false" by default for Azure Stack Cloud)
+      resourceGroup: "" # available values: EXISTING RESOURCE GROUP (If not specified, snapshot will be stored in the same resource group as source Azure disk)
+      tags: "" # tag format: 'key1=val1,key2=val2'
+    additionalLabels: {}
 
 feature:
   enableFSGroupPolicy: true

--- a/edgeless/tests/README.md
+++ b/edgeless/tests/README.md
@@ -1,35 +1,38 @@
 # CSI driver e2e tests
 
-Run end to end tests using the kubernetes `e2e.test` binary.
+Run CSI e2e tests using [`sonobuoy`](https://github.com/vmware-tanzu/sonobuoy/releases/latest).
 
-Download the binary for your Kubernetes version:
+## Generate test framework
+
+Generate CSI e2e test sonobuoy config:
 
 ```shell
-K8S_VER=1.23.0
-curl --location https://dl.k8s.io/v${K8S_VER}/kubernetes-test-linux-amd64.tar.gz | \
-  tar --strip-components=3 -zxf - kubernetes/test/bin/e2e.test
+KUBECONFIG=</path/to/kubeconfig`
+sonobuoy gen --e2e-focus='External.Storage' --e2e-skip='\[Disruptive\]' --kubeconfig=${KUBECONFIG} > sonobuoy.yaml
 ```
 
-For an overview on how to run tests read the [Kubernetes blog post](https://kubernetes.io/blog/2020/01/08/testing-of-csi-drivers/#end-to-end-testing).
+Apply driver patch:
+
+```shell
+patch sonobuoy.yaml < patch.diff
+```
 
 ## Running the test suite
 
-1. Set up the CSI driver
+Start the test:
 
-    ```shell
-    helm install azuredisk-csi-driver charts/edgeless/v1.0.0/azuredisk-csi-driver-v1.0.0.tgz \
-        --namespace kube-system \
-        --set controller.runOnMaster=true \
-        --set linux.distro=fedora \
-        --set controller.replicas=1
-    ```
+```shell
+kubectl apply -f sonobuoy.yaml
+```
 
-1. Run the tests
+Wait for tests to complete:
 
-    ```shell
-    ./e2e.test \
-        -ginkgo.v \
-        -ginkgo.focus='External.Storage' \
-        -ginkgo.skip='\[Disruptive\]' \
-        -storage.testdriver=driver.yaml
-    ```
+```shell
+sonobuoy wait
+```
+
+Analyze results:
+
+```shell
+sonobuoy results $(sonobuoy retrieve)
+```

--- a/edgeless/tests/README.md
+++ b/edgeless/tests/README.md
@@ -7,7 +7,7 @@ Run CSI e2e tests using [`sonobuoy`](https://github.com/vmware-tanzu/sonobuoy/re
 Generate CSI e2e test sonobuoy config:
 
 ```shell
-KUBECONFIG=</path/to/kubeconfig`
+KUBECONFIG=</path/to/kubeconfig>
 sonobuoy gen --e2e-focus='External.Storage' --e2e-skip='\[Disruptive\]' --kubeconfig=${KUBECONFIG} > sonobuoy.yaml
 ```
 

--- a/edgeless/tests/patch.diff
+++ b/edgeless/tests/patch.diff
@@ -1,0 +1,61 @@
+--- o.yaml	2023-04-13 12:13:33.181285060 +0200
++++ sonobuoy.yaml	2023-04-13 09:36:28.475532271 +0200
+@@ -64,6 +64,10 @@
+ data:
+   plugin-0.yaml: |-
+     podSpec:
++      volumes:
++      - name: csi-driver-config-volume
++        configMap:
++          name: csi-driver-test-config
+       containers: []
+       nodeSelector:
+         kubernetes.io/os: linux
+@@ -86,7 +90,7 @@
+       - /run_e2e.sh
+       env:
+       - name: E2E_EXTRA_ARGS
+-        value: --progress-report-url=http://localhost:8099/progress
++        value: --progress-report-url=http://localhost:8099/progress -storage.testdriver=/tmp/csi-cfg/driver.yaml
+       - name: E2E_FOCUS
+         value: External.Storage
+       - name: E2E_PARALLEL
+@@ -113,6 +117,8 @@
+       volumeMounts:
+       - mountPath: /tmp/sonobuoy/results
+         name: results
++      - mountPath: /tmp/csi-cfg
++        name: csi-driver-config-volume
+   plugin-1.yaml: |-
+     podSpec:
+       containers: []
+@@ -245,4 +251,28 @@
+     sonobuoy-component: aggregator
+   type: ClusterIP
+ ---
+-
++apiVersion: v1
++kind: ConfigMap
++metadata:
++  name: csi-driver-test-config
++  namespace: sonobuoy
++data: 
++  driver.yaml: |
++    StorageClass:
++      FromName: true
++    DriverInfo:
++      Name: azuredisk.csi.confidential.cloud
++      SupportedFsType:
++        ext4: {}
++        ext3: {}
++        ext2: {}
++        xfs: {}
++        btrfs: {}
++      Capabilities:
++        persistence: true
++        block: true
++        exec: true
++        nodeExpansion: true
++        controllerExpansion: true
++        onlineExpansion: true
++        topology: true


### PR DESCRIPTION
Prepare release v1.2.0:

* Update helm chart to latest upstream
* Bump version numbers
* Pin image versions by hash
* Update CSI e2e test guideline